### PR TITLE
Add cookie to count number of hits a client has created in its lifetime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     builder (3.1.4)
     daemons (1.1.9)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.9.1)
     execjs (2.0.1)
     hike (1.2.3)
     i18n (0.6.9)
@@ -90,7 +90,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sqlite3 (1.3.8)
+    sqlite3 (1.3.13)
     thin (1.6.1)
       daemons (>= 1.0.9)
       eventmachine (>= 1.0.0)
@@ -121,3 +121,6 @@ DEPENDENCIES
   sqlite3
   thin
   uglifier (>= 1.0.3)
+
+BUNDLED WITH
+   1.13.7

--- a/app/controllers/hits_controller.rb
+++ b/app/controllers/hits_controller.rb
@@ -16,6 +16,9 @@ before_filter :set_cache_headers
 
   def create
     response.headers["content-length"] = "0"
+
+    cookies.permanent[:hitCount] = cookies[:hitCount].to_i + 1
+
     @hit = Hit.new
     @hit.ip =  request.remote_ip || ''
     @hit.agent = request.env['HTTP_USER_AGENT'] || ''


### PR DESCRIPTION
The cookie count cookie value will show up in the HTTP_COOKIE header field after the first request.